### PR TITLE
分子が小さい拍子に対してCheddeaurchin使うとハマるっぽい

### DIFF
--- a/Cheddeaurchin/ChedScoreConverter.cs
+++ b/Cheddeaurchin/ChedScoreConverter.cs
@@ -344,7 +344,7 @@ namespace Cheddeaurchin
             var lastBeats = DefaultBeats;
             var lastTick = 0;
             var measureSum = 0u;
-            foreach (var bd in chedScore.Events.TimeSignatureChangeEvents)
+            foreach (var bd in tsigs)
             {
                 var diffTicks = bd.Tick - lastTick;
                 var diffMeasures = diffTicks / (lastBeats * TicksPerBeat);

--- a/Cheddeaurchin/ChedScoreConverter.cs
+++ b/Cheddeaurchin/ChedScoreConverter.cs
@@ -81,7 +81,7 @@ namespace Cheddeaurchin
             var rest = tick;
             var measure = 0u;
             var ticksPerMeasure = 0u;
-            while (rest > (ticksPerMeasure = (uint)GetBeatsAt(measure) * TicksPerBeat))
+            while (rest > (ticksPerMeasure = (uint)(GetBeatsAt(measure) * TicksPerBeat)))
             {
                 rest -= ticksPerMeasure;
                 ++measure;


### PR DESCRIPTION
拍子tickキャストの切り捨てで0になると無限ループになるくさいです

あと拍子定義初期化時にソート済みリストが使われてなかったんですが、コンボ数に影響はないっぽいのでいらなければ捨ててください